### PR TITLE
This is not working with HEX-String

### DIFF
--- a/lib/asn1ber.js
+++ b/lib/asn1ber.js
@@ -310,9 +310,11 @@ exports.parseOctetString = function (buf) {
         throw new Error('Buffer does not appear to be an OctetString');
     }
 
-    // SNMP doesn't specify an encoding so I pick UTF-8 as the 'most standard'
-    // encoding. We'll see if that assumption survives contact with actual reality.
-    return buf.toString('utf-8', 2, 2 + buf[1]);
+    var value = "";
+    for (var i = 2; i < buf.length; i++) {
+        value = value.concat(String.fromCharCode(buf[i]));
+    }
+    return value;
 };
 
 // Parse a buffer containing a representation of an ObjectIdentifier.


### PR DESCRIPTION
> snmpwalk -v 2c -c public 10.0.0.2 1.3.6.1.2.1.17.1.1.0
> SNMPv2-SMI::mib-2.17.1.1.0 = Hex-STRING: 00 0A 73 F4 47 C5
> Now its Ok...
> // buf = <Buffer 04 06 00 0a 73 f4 47 c5>
> output value: "\u0000\nsôGÅ", its is OK because is HEX.
