### PR TITLE
Added Support to GetBulkRequestPDU

### DIFF
--- a/lib/asn1ber.js
+++ b/lib/asn1ber.js
@@ -31,7 +31,8 @@ var P = {
     GetRequestPDU: 0x00,
     GetNextRequestPDU: 0x01,
     GetResponsePDU: 0x02,
-    SetRequestPDU: 0x03
+    SetRequestPDU: 0x03,
+    GetBulkRequestPDU: 0x05
 };
 
 var LOG256 = Math.log(256);

--- a/lib/snmp.js
+++ b/lib/snmp.js
@@ -17,6 +17,7 @@
 var assert = require('assert');
 var dgram = require('dgram');
 var events = require('events');
+var util = require('util');
 
 // We also need our ASN.1 BER en-/decoding routines.
 var asn1ber = require('./asn1ber');
@@ -36,6 +37,8 @@ function PDU() {
     this.reqid = 1;
     this.error = 0;
     this.errorIndex = 0;
+    this.nonRepeaters = 0;
+    this.maxRepetitions = 16;
     this.varbinds = [ new VarBind() ];
 }
 
@@ -138,7 +141,7 @@ function defaults(targ, _defs) {
 // Return an ASN.1 BER encoding of a Packet structure.
 // This is suitable for transmission on a UDP socket.
 function encode(pkt) {
-    var version, community, reqid, err, erridx, vbs, pdu, message;
+    var version, community, reqid, err, erridx, norep, maxrep, vbs, pdu, message;
 
     // We only support SNMPv2c, so enforce that version stamp.
     if (pkt.version !== 1) {
@@ -151,8 +154,13 @@ function encode(pkt) {
 
     // Encode the PDU header fields.
     reqid = asn1ber.encodeInteger(pkt.pdu.reqid);
-    err = asn1ber.encodeInteger(pkt.pdu.error);
-    erridx = asn1ber.encodeInteger(pkt.pdu.errorIndex);
+    if ( pkt.pdu.type == asn1ber.pduTypes.GetBulkRequestPDU ) {
+        norep = asn1ber.encodeInteger(pkt.pdu.nonRepeaters); 
+        maxrep = asn1ber.encodeInteger(pkt.pdu.maxRepetitions);
+    } else {
+        err = asn1ber.encodeInteger(pkt.pdu.error);
+        erridx = asn1ber.encodeInteger(pkt.pdu.errorIndex);
+    }
 
     // Encode the PDU varbinds.
     vbs = [];
@@ -179,7 +187,11 @@ function encode(pkt) {
     vbs = asn1ber.encodeSequence(concatBuffers(vbs));
 
     // Create the PDU by concatenating the inner fields and adding a request structure around it.
-    pdu = asn1ber.encodeRequest(pkt.pdu.type, concatBuffers([reqid, err, erridx, vbs]));
+    if ( pkt.pdu.type == asn1ber.pduTypes.GetBulkRequestPDU ) {
+        pdu = asn1ber.encodeRequest(pkt.pdu.type, concatBuffers([reqid, norep, maxrep, vbs]));
+    } else {
+        pdu = asn1ber.encodeRequest(pkt.pdu.type, concatBuffers([reqid, err, erridx, vbs]));
+    }
 
     // Create the message by concatenating the header fields and the PDU.
     message = asn1ber.encodeSequence(concatBuffers([version, community, pdu]));
@@ -392,6 +404,7 @@ function msgReceived(msg, rinfo) {
     // If this message's request id matches one we've sent,
     // cancel any outstanding timeout and call the registered
     // callback.
+
     entry = self.reqs[pkt.pdu.reqid];
     if (entry) {
         clearRequest(self.reqs, pkt.pdu.reqid);
@@ -442,11 +455,13 @@ function Session(options) {
         // it when it's closed.
         self.socket = undefined;
     });
-    self.socket.on('error', function () {
+    self.socket.on('error', function (err) {
         // Errors will be emitted here as well as on the callback to the send function.
         // We handle them there, so doing anything here is unnecessary.
         // But having no error handler trips up the test suite.
     });
+    //this avoid problem with multiple process in cluster
+    self.socket.bind(Math.floor(Math.random()*(65535-1024+1)+1024));
 }
 
 // We inherit from EventEmitter so that we can emit error events
@@ -673,7 +688,27 @@ Session.prototype.getNext = function (options, callback) {
 
     pkt = new Packet();
     pkt.community = options.community;
-    pkt.pdu.type = 1;
+    pkt.pdu.type = asn1ber.pduTypes.GetNextRequestPDU;
+    pkt.pdu.varbinds[0].oid = options.oid;
+    self.sendMsg(pkt, options, callback);
+};
+
+// Shortcut to create a GetNextBulkRequest and send it, while registering a callback.
+// Needs `options.oid` to be an OID in array form.
+
+Session.prototype.getNextBulk = function (options, callback) {
+    var self = this, pkt = [];
+
+    defaults(options, self.options);
+    parseOids(options);
+
+    if (!options.oid) {
+        return callback(null, []);
+    }
+
+    pkt = new Packet();
+    pkt.community = options.community;
+    pkt.pdu.type = asn1ber.pduTypes.GetBulkRequestPDU;
     pkt.pdu.varbinds[0].oid = options.oid;
     self.sendMsg(pkt, options, callback);
 };
@@ -737,8 +772,79 @@ Session.prototype.getSubtree = function (options, callback) {
     self.getNext(options, result);
 };
 
+// Shortcut to get all entries below the specified OID.
+// The callback will be called once with the list of
+// varbinds that was collected, or with an error object.
+// Needs `options.oid` to be an OID in array form.
+
+Session.prototype.getSubtreeBulk = function (options, callback) {
+    var self = this, vbs = [];
+
+    defaults(options, self.options);
+    parseOids(options);
+
+    if (!options.oid) {
+        return callback(null, []);
+    }
+
+    options.startOid = options.oid;
+
+    // Helper to check whether `oid` in inside the tree rooted at
+    // `root` or not.
+    function inTree(root, oid) {
+        var i;
+        if (oid.length <= root.length) {
+            return false;
+        }
+        for (i = 0; i < root.length; i++) {
+            if (oid[i] !== root[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // Helper to handle the result of getNext and call the user's callback
+    // as appropriate. The callback will see one of the following patterns:
+    //  - callback([an Error object], undefined) -- an error ocurred.
+    //  - callback(null, [a Packet object]) -- data from under the tree.
+    //  - callback(null, null) -- end of tree.
+    function result(error, varbinds) {
+        var i;
+        if (error) {
+            callback(error);
+        } else {
+            var next = null;
+            for (i = 0; i < varbinds.length; i++) {
+                if (inTree(options.startOid, varbinds[i].oid)) {
+                    if (varbinds[i].value === 'endOfMibView' || varbinds[i].value === 'noSuchObject' || varbinds[i].value === 'noSuchInstance') {
+                        next = null;
+                    } else {
+                        vbs.push(varbinds[i]);
+                        next = { oid: varbinds[i].oid };
+                    }
+                } else {
+                    next = null;
+                }
+            }
+            if ( next != null ) {
+                defaults(next, options);
+                self.getNextBulk(next, result);
+            } else {
+                callback(null, vbs);
+            }
+        }
+    }
+
+    self.getNextBulk(options, result);
+};
+
 // Close the socket. Necessary to finish the event loop and exit the program.
 
 Session.prototype.close = function () {
-    this.socket.close();
+    try{
+        this.socket.close();
+    } catch ( err ) {
+        this.socket = null;
+    }
 };


### PR DESCRIPTION
Example for Testing:

```nodejs
#!/usr/bin/nodejs

var snmp = require('snmp-native');
var util = require('util');

// host
var host = '127.0.0.1';
var community = 'public';

// oids
var _sysDescr = [1, 3, 6, 1, 2, 1, 1, 1, 0];
var _ifName = [1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 1];
var _ifSpeed = [1, 3, 6, 1, 2, 1, 2, 2, 1, 5];

// session
var snmpSession1 = new snmp.Session({
    host: host,
    community: community
});
snmpSession1.get({
    oid: _sysDescr
}, function(err, varBinds) {
    console.log(" #1, err: " + util.inspect(err, false, null));
    console.log(" #1, varBinds: " + util.inspect(varBinds, false, null));
    snmpSession1.close();
});
/**/

// session, make one request for each oid in the tree, check the requestId, is diferent
var snmpSession2 = new snmp.Session({
    host: host,
    community: community
});
snmpSession2.getSubtree({
    oid: _ifName
}, function(err, varBinds) {
    console.log(" #2, err: " + util.inspect(err, false, null));
    console.log(" #2, varBinds: " + util.inspect(varBinds, false, null));
    snmpSession2.close();
});
/**/

// session, make just one request for all oids in tree, check the requestId, is the same
var snmpSession3 = new snmp.Session({
    host: host,
    community: community
});
snmpSession3.getSubtreeBulk({
    oid: _ifSpeed
}, function(err, varBinds) {
    console.log(" #3, err: " + util.inspect(err, false, null));
    console.log(" #3, varBinds: " + util.inspect(varBinds, false, null));
    snmpSession3.close();
});
/**/
```