### PR TITLE
Fixed the error slice buffer, which was spammed valueRaw

### DIFF
--- a/lib/snmp.js
+++ b/lib/snmp.js
@@ -246,7 +246,7 @@ function parse(buf) {
         // Slice off the sequence header.
         hdr = asn1ber.typeAndLength(buf);
         assert.equal(asn1ber.types.Sequence, hdr.type);
-        bvb = buf.slice(hdr.header);
+        bvb = buf.slice(hdr.header, hdr.len + hdr.header);
 
         // Parse and save the ObjectIdentifier.
         vb.oid = asn1ber.parseOid(bvb);


### PR DESCRIPTION
Hello! 

Here's a script that reproduces the error.

It is possible that these OID will not be on your machine, then you can add any of the 2 (or more) OID type OCTET STRING (other types I have not tested)

```js
var oids, session, snmp;

snmp = require('./node-snmp-native');

session = new snmp.Session({
    host:       '127.0.0.1',
    port:       161,
    community:  'public'
});

// There must be more than 2 OID {OCTET STRING}
oids = [
    '.1.3.6.1.4.1.0.0.0.10.2.1.0',
    '.1.3.6.1.4.1.0.0.0.10.2.2.0',
    '.1.3.6.1.4.1.0.0.0.10.2.3.0',
    '.1.3.6.1.4.1.0.0.0.10.2.4.0'
];

session.getAll({oids: oids}, function(error, varbinds) {
    if (error) {
      return console.error('Fail :-(');
    } else {
      varbinds.forEach(function(val) {
        return console.log("" + (val.oid.join('.')) + "=", val.value, val.valueRaw.toString(), val.valueRaw);
      });
      return session.close();
    }
});
```

Error

```
➜  /tmp  nodejs test.js                  
1.3.6.1.4.1.0.0.0.10.2.1.0= n/a n/a0
                                      +
n/a0
          +
n/a0
          +
n/a <Buffer 6e 2f 61 30 13 06 0c 2b 06 01 04 01 00 00 00 0a 02 02 00 04 03 6e 2f 61 30 13 06 0c 2b 06 01 04 01 00 00 00 0a 02 03 00 04 03 6e 2f 61 30 13 06 0c 2b 06 ...>
1.3.6.1.4.1.0.0.0.10.2.2.0= n/a n/a0
                                      +
n/a0
          +
n/a <Buffer 6e 2f 61 30 13 06 0c 2b 06 01 04 01 00 00 00 0a 02 03 00 04 03 6e 2f 61 30 13 06 0c 2b 06 01 04 01 00 00 00 0a 02 04 00 04 03 6e 2f 61>
1.3.6.1.4.1.0.0.0.10.2.3.0= n/a n/a0
                                      +
n/a <Buffer 6e 2f 61 30 13 06 0c 2b 06 01 04 01 00 00 00 0a 02 04 00 04 03 6e 2f 61>
1.3.6.1.4.1.0.0.0.10.2.4.0= n/a n/a <Buffer 6e 2f 61>
```

Fixed
```
1.3.6.1.4.1.0.0.0.10.2.1.0= n/a <Buffer 6e 2f 61>
1.3.6.1.4.1.0.0.0.10.2.2.0= n/a <Buffer 6e 2f 61>
1.3.6.1.4.1.0.0.0.10.2.3.0= n/a <Buffer 6e 2f 61>
1.3.6.1.4.1.0.0.0.10.2.4.0= n/a <Buffer 6e 2f 61>
```