### PR TITLE
Adds support for SNMPv1 Trap responses

### DIFF
--- a/lib/asn1ber.js
+++ b/lib/asn1ber.js
@@ -31,7 +31,8 @@ var P = {
     GetRequestPDU: 0x00,
     GetNextRequestPDU: 0x01,
     GetResponsePDU: 0x02,
-    SetRequestPDU: 0x03
+    SetRequestPDU: 0x03,
+    TrapPDU: 0x04
 };
 
 var E = {

--- a/lib/asn1ber.js
+++ b/lib/asn1ber.js
@@ -159,7 +159,7 @@ function intArray(val) {
         array.push(0);
     } else {
         if (val < 0) {
-            bytes = Math.floor(1 + Math.log(-val) / LOG256)
+            bytes = Math.floor(1 + Math.log(-val) / LOG256);
             // Encode negatives as 32-bit two's complement. Let's hope that fits.
             encVal += Math.pow(2, 8 * bytes);
         }
@@ -204,27 +204,27 @@ function encodeIntegerish(val, type) {
     }
 
     return buf;
-};
+}
 
 // Integer type, 0x02
 exports.encodeInteger = function (val) {
     return(encodeIntegerish(val, T.Integer));
-}
+};
 
 // Gauge type, 0x42
 exports.encodeGauge = function (val) {
     return(encodeIntegerish(val, T.Gauge));
-}
+};
 
 // Counter type, 0x41
 exports.encodeCounter = function (val) {
     return(encodeIntegerish(val, T.Counter));
-}
+};
 
 // TimeTicks type, 0x43
 exports.encodeTimeTicks = function (val) {
     return(encodeIntegerish(val, T.TimeTicks));
-}
+};
 
 // Create the representation of a Null, `05 00`.
 
@@ -390,8 +390,8 @@ exports.parseOctetString = function (buf) {
         lenBytes = len - 128;
         len = 0;
         for (i = 0; i < lenBytes; i++) {
-            len *= 256
-            len += buf[2+i]
+            len *= 256;
+            len += buf[2+i];
         }
     }
     return buf.toString('utf-8', 2 + lenBytes, 2 + lenBytes + len);

--- a/lib/snmp.js
+++ b/lib/snmp.js
@@ -49,6 +49,17 @@ function PDU() {
     this.varbinds = [ new VarBind() ];
 }
 
+// The SNMPv1 `Trap PDU`
+function TrapPDU() {
+	this.type = asn1ber.pduTypes.TrapPDU;
+	this.enterpriseOid = null;
+	this.networkAddress = null;
+	this.trapType = 6;
+	this.specificTrapType = null;
+	this.timeStamp = null;
+	this.varbinds = [new VarBind()];
+}
+
 // The `Packet` contains the SNMP version and community and the `PDU`.
 function Packet() {
     this.version = versions.SNMPv2c;
@@ -237,17 +248,43 @@ function parse(buf) {
     pkt.pdu.type = hdr.type - 0xA0;
     buf = buf.slice(hdr.header);
 
-    // The request id field.
-    pkt.pdu.reqid = asn1ber.parseInteger(buf.slice(0, buf[1] + 2));
-    buf = buf.slice(2 + buf[1]);
+   // If PDU is not a SNMPv1 Trap
+	if (pkt.pdu.type !== asn1ber.pduTypes.TrapPDU) {
+		// The request id field.
+		pkt.pdu.reqid = asn1ber.parseInteger(buf.slice(0, buf[1] + 2));
+		buf = buf.slice(2 + buf[1]);
 
-    // The error field.
-    pkt.pdu.error = asn1ber.parseInteger(buf.slice(0, buf[1] + 2));
-    buf = buf.slice(2 + buf[1]);
+		// The error field.
+		pkt.pdu.error = asn1ber.parseInteger(buf.slice(0, buf[1] + 2));
+		buf = buf.slice(2 + buf[1]);
 
-    // The error index field.
-    pkt.pdu.errorIndex = asn1ber.parseInteger(buf.slice(0, buf[1] + 2));
-    buf = buf.slice(2 + buf[1]);
+		// The error index field.
+		pkt.pdu.errorIndex = asn1ber.parseInteger(buf.slice(0, buf[1] + 2));
+		buf = buf.slice(2 + buf[1]);
+	} else {
+		//PDU is a SNMPv1 Trap
+		pkt.pdu = new TrapPDU();
+
+		// The enterprise id
+		pkt.pdu.enterpriseOid = asn1ber.parseOid(buf.slice(0, buf[1] + 2));
+		buf = buf.slice(2 + buf[1]);
+		
+		// The ip address
+		pkt.pdu.networkAddress = asn1ber.parseArray(buf.slice(0, buf[1] + 2));
+		buf = buf.slice(2 + buf[1]);
+		
+		// The trap type
+		pkt.pdu.trapType = asn1ber.parseInteger(buf.slice(0, buf[1] + 2));
+		buf = buf.slice(2 + buf[1]);
+		
+		// The specific trap type
+		pkt.pdu.specificTrapType = asn1ber.parseInteger(buf.slice(0, buf[1] + 2));
+		buf = buf.slice(2 + buf[1]);
+		
+		// The time stamp
+		pkt.pdu.timeStamp = asn1ber.parseInteger(buf.slice(0, buf[1] + 2));
+		buf = buf.slice(2 + buf[1]);
+	}
 
     // Here's the varbind list. Not interested.
     hdr = asn1ber.typeAndLength(buf);

--- a/lib/snmp.js
+++ b/lib/snmp.js
@@ -28,7 +28,7 @@ exports.Errors = asn1ber.errors;
 var versions = {
     SNMPv1: 0,
     SNMPv2c: 1
-}
+};
 exports.Versions = versions;
 
 // Basic structures
@@ -272,8 +272,8 @@ function parse(buf) {
         // routine. For the SNMPv2c error types, we simply set the
         // value to a text representation of the error and leave handling
         // up to the user.
-        vbhdr = asn1ber.typeAndLength(bvb)
-        bvb = bvb.slice(vbhdr.header + vbhdr.len)
+        vbhdr = asn1ber.typeAndLength(bvb);
+        bvb = bvb.slice(vbhdr.header + vbhdr.len);
         vb.type = bvb[0];
         if (vb.type === asn1ber.types.Null) {
             // Null type.


### PR DESCRIPTION
This request adds support for SNMPv1 trap responses per: http://tools.ietf.org/html/rfc1157#page-27 and http://www-01.ibm.com/support/knowledgecenter/SSB23S_1.1.0.10/com.ibm.ztpf-ztpfdf.doc_put.10/gtpc1/pdus.html.

You can now receive trap messages from legacy network devices.
Also minor syntax issues were corrected.
