### PR TITLE
Fixed minor OID validation bug

### DIFF
--- a/lib/asn1ber.js
+++ b/lib/asn1ber.js
@@ -129,7 +129,7 @@ function oidArray(oid, skipValidation) {
     // Enforce some minimum requirements on the OID.
     if (oid.length < 2) {
         throw new Error("Minimum OID length is two.");
-    } else if (!skipValidation && (oid[0] !== 1 || oid[1] !== 3)) {
+    } else if (!skipValidation && oid[0] !== 1) {
         throw new Error("SNMP OIDs always start with .1.3.");
     }
 

--- a/test/asn1ber.js
+++ b/test/asn1ber.js
@@ -245,7 +245,7 @@ describe('asn1ber', function () {
         });
         it('throws an exception for incorrect SNMP OIDs', function (done) {
             try {
-                asn1ber.encodeOid([1, 5, 6, 7, 8]);
+                asn1ber.encodeOid([2, 5, 6, 7, 8]);
             } catch (err) {
                 assert.equal("SNMP OIDs always start with .1.3.", err.message);
                 done();
@@ -259,6 +259,12 @@ describe('asn1ber', function () {
         it('returns an oid correctly', function () {
             var oid = [1, 3, 6, 1, 4, 1, 2680, 1234567, 2, 7, 3, 2, 0];
             var correct = '06 0f 2b 06 01 04 01 94 78 cb ad 07 02 07 03 02 00'.replace(/ /g, '');
+            var buf = asn1ber.encodeOid(oid);
+            assert.equal(correct, buf.toString('hex'));
+        });
+        it('returns an oid correctly even though the oid doesn\'t start with .1.3', function () {
+            var oid = [1, 0, 8802, 1, 1, 2, 1, 4, 1, 1, 9];
+            var correct = '06 0b 28 c4 62 01 01 02 01 04 01 01 09'.replace(/ /g, '');
             var buf = asn1ber.encodeOid(oid);
             assert.equal(correct, buf.toString('hex'));
         });


### PR DESCRIPTION
Please note that I kept most of the else-if statement because the check oid[0] !== 1 is correct since every OID must start with a 1. I've adapted the tests accordingly.