### PR TITLE
Add support to module cluster workers

### DIFF
--- a/lib/snmp.js
+++ b/lib/snmp.js
@@ -464,6 +464,13 @@ function Session(options) {
         // We handle them there, so doing anything here is unnecessary.
         // But having no error handler trips up the test suite.
     });
+    // If exclusive is false (default), then cluster workers will use the same underlying handle, 
+    // allowing connection handling duties to be shared. 
+    // When exclusive is true, the handle is not shared, and attempted port sharing results in an error.
+    self.socket.bind({
+        port: 0, //get a random port automatically
+        exclusive: true // you should not share the same port, otherwise yours packages will be screwed up between workers
+    });    
 }
 
 // We inherit from EventEmitter so that we can emit error events


### PR DESCRIPTION
Get a random port automatically, even if you are using cluster workers.