### PR TITLE
add cancel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,17 @@ it without a callback:
 session.set({ oid: [1, 3, 6, 1, 4, 1, 42, 1, 0], value: 42, type: 2 });
 ```
 
+### close()
+
+Cancels all outstanding requests and frees used OS resources. Outstanding
+requests will call their callback with the "Cancelled" error set.
+
+Example:
+
+```javascript
+session.close();
+```
+
 License
 =======
 

--- a/lib/snmp.js
+++ b/lib/snmp.js
@@ -779,3 +779,15 @@ Session.prototype.getSubtree = function (options, callback) {
 Session.prototype.close = function () {
     this.socket.close();
 };
+
+// Cancel all current request and close the session
+Session.prototype.cancel = function () {
+    var self = this;
+    for (var reqid in self.reqs) {
+      if (self.reqs[reqid].callback) {
+        self.reqs[reqid].callback(new Error('Cancelled'));
+      }
+      clearRequest(self.reqs, reqid);
+    }
+    this.close();
+};

--- a/lib/snmp.js
+++ b/lib/snmp.js
@@ -775,13 +775,7 @@ Session.prototype.getSubtree = function (options, callback) {
 };
 
 // Close the socket. Necessary to finish the event loop and exit the program.
-
 Session.prototype.close = function () {
-    this.socket.close();
-};
-
-// Cancel all current request and close the session
-Session.prototype.cancel = function () {
     var self = this;
     for (var reqid in self.reqs) {
       if (self.reqs[reqid].callback) {
@@ -789,5 +783,5 @@ Session.prototype.cancel = function () {
       }
       clearRequest(self.reqs, reqid);
     }
-    this.close();
+    this.socket.close();
 };


### PR DESCRIPTION
This adds support for canceling active requests in the session.

Open questions:
 - Is the name ok? Is cancleActiveRequests() perhaps better?
- Should we call close or leave the session available for reuse?

TODO:
- [ ] Documentation