### PR TITLE
add deadline support to getAll

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,11 +172,14 @@ flooding hosts. Options:
    '.1.3.6.1.4.1.2.3.4.5']`.
  - `abortOnError`: Whether to stop or continue when an error is encountered.
    Default: `false`.
+ - `combinedTimeout`: Timeout in milliseconds that the getAll() may take.
+   Default: no timeout.
 
 The callback will be called with an error object or a list of varbinds. If the
 options property `abortOnError` is false (default) any variables that couldn't
 be fetched will simply be omitted from the results. If it is true, the callback
-will be called with an error object on any failure.
+will be called with an error object on any failure. If the `combinedTimeout` is
+triggered, the callback is called with an error and the partial results.
 
 ```javascript
 var oids = [ [1, 3, 6, 1, 4, 1, 42, 1, 0], [1, 3, 6, 1, 4, 1, 42, 2, 0], ... ];
@@ -192,9 +195,12 @@ session.getAll({ oids: oids }, function (error, varbinds) {
 Perform repeated GetNextRequests to fetch all values in the specified tree. Options:
 
  - `oid`: The OID to get. Example: `[1, 3, 6, 1, 4, 1, 1, 2, 3, 4]` or `'.1.3.6.1.4.1.1.2.3.4'`.
+ - `combinedTimeout`: Timeout in milliseconds that the getSubtree() may take.
+   Default: no timeout.
 
 Will call the specified `callback` with an `error` object (`null` on success)
-and the list of varbinds that was fetched.
+and the list of varbinds that was fetched. If the `combinedTimeout` is triggered,
+the callback is called with an error and the partial results.
 
 ```javascript
 session.getSubtree({ oid: [1, 3, 6, 1, 4, 1, 42] }, function (error, varbinds) {

--- a/lib/snmp.js
+++ b/lib/snmp.js
@@ -648,7 +648,7 @@ Session.prototype.set = function (options, callback) {
 
 Session.prototype.getAll = function (options, callback) {
     var self = this, results = [],
-      combinedTimeoutTimer = null, combinedTimeoutExpired = false;
+        combinedTimeoutTimer = null, combinedTimeoutExpired = false;
 
     defaults(options, self.options, { abortOnError: false });
     parseOids(options);
@@ -678,7 +678,7 @@ Session.prototype.getAll = function (options, callback) {
 
         self.sendMsg(pkt, options, function (err, varbinds) {
             if (combinedTimeoutExpired) {
-              return;
+                return;
             }
             if (options.abortOnError && err) {
                 clearTimeout(combinedTimeoutTimer);
@@ -698,11 +698,11 @@ Session.prototype.getAll = function (options, callback) {
     }
 
     if (options.combinedTimeout) {
-      var combinedTimeoutEvent = function() {
-        combinedTimeoutExpired = true;
-        return callback(new Error('Timeout'), results);
-      };
-      combinedTimeoutTimer = setTimeout(combinedTimeoutEvent, options.combinedTimeout);
+        var combinedTimeoutEvent = function() {
+            combinedTimeoutExpired = true;
+            return callback(new Error('Timeout'), results);
+        };
+        combinedTimeoutTimer = setTimeout(combinedTimeoutEvent, options.combinedTimeout);
     }
 
     getOne(0);

--- a/lib/snmp.js
+++ b/lib/snmp.js
@@ -647,7 +647,8 @@ Session.prototype.set = function (options, callback) {
 // and any successfully retrieved values sent to the callback.
 
 Session.prototype.getAll = function (options, callback) {
-    var self = this, results = [];
+    var self = this, results = [],
+      deadlineTimer = null, deadlineExpired = false;
 
     defaults(options, self.options, { abortOnError: false });
     parseOids(options);
@@ -676,19 +677,35 @@ Session.prototype.getAll = function (options, callback) {
         }
 
         self.sendMsg(pkt, options, function (err, varbinds) {
-            if (options.abortOnError && err) {
-                callback(err);
-            } else {
-                if (varbinds) {
-                    results = results.concat(varbinds);
-                }
-                if (c < options.oids.length) {
-                    getOne(c);
+            if (!deadlineExpired) {
+                if (options.abortOnError && err) {
+                    if (!deadlineExpired) {
+                        clearTimeout(deadlineTimer);
+                    }
+                    callback(err);
                 } else {
-                    callback(null, results);
+                    if (varbinds) {
+                        results = results.concat(varbinds);
+                    }
+                    if (c < options.oids.length) {
+                        getOne(c);
+                    } else {
+                        if (!deadlineExpired) {
+                            clearTimeout(deadlineTimer);
+                        }
+                        callback(null, results);
+                    }
                 }
             }
         });
+    }
+
+    if (options.deadline) {
+      function deadlineExpiredEvent() {
+        deadlineExpired = true;
+        return callback(new Error('Deadline exceeded'), results);
+      }
+      deadlineTimer = setTimeout(deadlineExpiredEvent, options.deadline);
     }
 
     getOne(0);

--- a/lib/snmp.js
+++ b/lib/snmp.js
@@ -648,7 +648,7 @@ Session.prototype.set = function (options, callback) {
 
 Session.prototype.getAll = function (options, callback) {
     var self = this, results = [],
-      deadlineTimer = null, deadlineExpired = false;
+      combinedTimeoutTimer = null, combinedTimeoutExpired = false;
 
     defaults(options, self.options, { abortOnError: false });
     parseOids(options);
@@ -677,11 +677,11 @@ Session.prototype.getAll = function (options, callback) {
         }
 
         self.sendMsg(pkt, options, function (err, varbinds) {
-            if (deadlineExpired) {
+            if (combinedTimeoutExpired) {
               return;
             }
             if (options.abortOnError && err) {
-                clearTimeout(deadlineTimer);
+                clearTimeout(combinedTimeoutTimer);
                 callback(err);
             } else {
                 if (varbinds) {
@@ -690,19 +690,19 @@ Session.prototype.getAll = function (options, callback) {
                 if (c < options.oids.length) {
                     getOne(c);
                 } else {
-                    clearTimeout(deadlineTimer);
+                    clearTimeout(combinedTimeoutTimer);
                     callback(null, results);
                 }
             }
         });
     }
 
-    if (options.deadline) {
-      var deadlineExpiredEvent = function() {
-        deadlineExpired = true;
-        return callback(new Error('Deadline exceeded'), results);
-      }
-      deadlineTimer = setTimeout(deadlineExpiredEvent, options.deadline);
+    if (options.combinedTimeout) {
+      var combinedTimeoutEvent = function() {
+        combinedTimeoutExpired = true;
+        return callback(new Error('Timeout'), results);
+      };
+      combinedTimeoutTimer = setTimeout(combinedTimeoutEvent, options.combinedTimeout);
     }
 
     getOne(0);

--- a/lib/snmp.js
+++ b/lib/snmp.js
@@ -677,31 +677,28 @@ Session.prototype.getAll = function (options, callback) {
         }
 
         self.sendMsg(pkt, options, function (err, varbinds) {
-            if (!deadlineExpired) {
-                if (options.abortOnError && err) {
-                    if (!deadlineExpired) {
-                        clearTimeout(deadlineTimer);
-                    }
-                    callback(err);
+            if (deadlineExpired) {
+              return;
+            }
+            if (options.abortOnError && err) {
+                clearTimeout(deadlineTimer);
+                callback(err);
+            } else {
+                if (varbinds) {
+                    results = results.concat(varbinds);
+                }
+                if (c < options.oids.length) {
+                    getOne(c);
                 } else {
-                    if (varbinds) {
-                        results = results.concat(varbinds);
-                    }
-                    if (c < options.oids.length) {
-                        getOne(c);
-                    } else {
-                        if (!deadlineExpired) {
-                            clearTimeout(deadlineTimer);
-                        }
-                        callback(null, results);
-                    }
+                    clearTimeout(deadlineTimer);
+                    callback(null, results);
                 }
             }
         });
     }
 
     if (options.deadline) {
-      function deadlineExpiredEvent() {
+      var deadlineExpiredEvent = function() {
         deadlineExpired = true;
         return callback(new Error('Deadline exceeded'), results);
       }

--- a/lib/snmp.js
+++ b/lib/snmp.js
@@ -735,7 +735,8 @@ Session.prototype.getNext = function (options, callback) {
 // Needs `options.oid` to be an OID in array form.
 
 Session.prototype.getSubtree = function (options, callback) {
-    var self = this, vbs = [];
+    var self = this, vbs = [],
+        combinedTimeoutTimer = null, combinedTimeoutExpired = false;
 
     defaults(options, self.options);
     parseOids(options);
@@ -767,11 +768,16 @@ Session.prototype.getSubtree = function (options, callback) {
     //  - callback(null, [a Packet object]) -- data from under the tree.
     //  - callback(null, null) -- end of tree.
     function result(error, varbinds) {
+        if (combinedTimeoutExpired) {
+            return;
+        }
         if (error) {
+            clearTimeout(combinedTimeoutTimer);
             callback(error);
         } else {
             if (inTree(options.startOid, varbinds[0].oid)) {
                 if (varbinds[0].value === 'endOfMibView' || varbinds[0].value === 'noSuchObject' || varbinds[0].value === 'noSuchInstance') {
+                    clearTimeout(combinedTimeoutTimer);
                     callback(null, vbs);
                 } else {
                     vbs.push(varbinds[0]);
@@ -780,9 +786,18 @@ Session.prototype.getSubtree = function (options, callback) {
                     self.getNext(next, result);
                 }
             } else {
+                clearTimeout(combinedTimeoutTimer);
                 callback(null, vbs);
             }
         }
+    }
+
+    if (options.combinedTimeout) {
+        var combinedTimeoutEvent = function() {
+            combinedTimeoutExpired = true;
+            return callback(new Error('Timeout'), results);
+        };
+        combinedTimeoutTimer = setTimeout(combinedTimeoutEvent, options.combinedTimeout);
     }
 
     self.getNext(options, result);


### PR DESCRIPTION
This adds deadline support, meaning the getAll request will be aborted if it takes longer than the deadline.

The current timeout value only applies to individual snmp request. Functions like getAll and getSubtree possible do multiple request. The deadline is a way to enforce an upper limit on how long a getAll may take.

### TODO

- [ ] Documentation
- [x] deadline for getSubtree