### PR TITLE
Encoders for NoSuchObject, NoSuchInstance, and EndOfMibView

### DIFF
--- a/lib/asn1ber.js
+++ b/lib/asn1ber.js
@@ -253,6 +253,30 @@ exports.encodeNull = function () {
     return buf;
 };
 
+// NoSuchObject type, 0x80
+exports.encodeNoSuchObject = function() {
+    var buf = new Buffer(2);
+    buf[0] = T.NoSuchObject;
+    buf[1] = 0;
+    return buf;
+};
+
+// NoSuchInstance type, 0x81
+exports.encodeNoSuchInstance = function() {
+    var buf = new Buffer(2);
+    buf[0] = T.NoSuchInstance;
+    buf[1] = 0;
+    return buf;
+};
+
+// EndOfMibView type, 0x82
+exports.encodeEndOfMibView = function() {
+    var buf = new Buffer(2);
+    buf[0] = T.EndOfMibView;
+    buf[1] = 0;
+    return buf;
+};
+
 // Encode a Sequence, which is a wrapper of type `30`.
 
 exports.encodeSequence = function (contents) {

--- a/lib/snmp.js
+++ b/lib/snmp.js
@@ -185,6 +185,12 @@ function encode(pkt) {
             val = asn1ber.encodeCounter(vb.value);
         } else if (vb.type === asn1ber.types.TimeTicks) {
             val = asn1ber.encodeTimeTicks(vb.value);
+        } else if (vb.type === asn1ber.types.NoSuchObject) {
+            val = asn1ber.encodeNoSuchObject();
+        } else if (vb.type === asn1ber.types.NoSuchInstance) {
+            val = asn1ber.encodeNoSuchInstance();
+        } else if (vb.type === asn1ber.types.EndOfMibView) {
+            val = asn1ber.encodeEndOfMibView();
         } else {
             throw new Error('Unknown varbind type "' + vb.type + '" in encoding.');
         }

--- a/test/asn1ber.js
+++ b/test/asn1ber.js
@@ -158,6 +158,33 @@ describe('asn1ber', function () {
         });
     });
 
+    describe('encodeNoSuchObject()', function() {
+        it('returns the noSuchObject representation', function () {
+            var buf = asn1ber.encodeNoSuchObject();
+            assert.equal(2, buf.length);
+            assert.equal(0x80, buf[0]); // Null
+            assert.equal(0, buf[1]); // Zero
+        });
+    });
+
+    describe('encodeNoSuchInstance()', function() {
+        it('returns the noSuchInstance representation', function () {
+            var buf = asn1ber.encodeNoSuchInstance();
+            assert.equal(2, buf.length);
+            assert.equal(0x81, buf[0]); // Null
+            assert.equal(0, buf[1]); // Zero
+        });
+    });
+
+    describe('encodeEndOfMibView()', function() {
+        it('returns the endOfMibView representation', function () {
+            var buf = asn1ber.encodeEndOfMibView();
+            assert.equal(2, buf.length);
+            assert.equal(0x82, buf[0]); // Null
+            assert.equal(0, buf[1]); // Zero
+        });
+    });
+
     describe('encodeSequence()', function () {
         it('returns an empty sequence', function () {
             var buf = asn1ber.encodeSequence(new Buffer(0));

--- a/test/snmp.js
+++ b/test/snmp.js
@@ -48,6 +48,48 @@ describe('snmp', function () {
             var msg = snmp.encode(pkt);
             assert.equal(msg.toString('hex'), correct);
         });
+        it('returns a correctly formatted buffer from a NoSuchObject packet', function () {
+            var correct = '302c 0201 0104 0770 7269 7661 7465 a01e 0201 0502 0106 0201 0730 1330 1106 0d2b 0601 0401 9478 0102 0703 0200 8000'.replace(/ /g, '');
+            var pkt = new snmp.Packet(); // A default getrequest
+            pkt.community = 'private';
+            pkt.pdu.reqid = 5;
+            pkt.pdu.error = 6;
+            pkt.pdu.errorIndex = 7;
+            pkt.pdu.varbinds = [{
+                type: 0x80,
+                oid: [1, 3, 6, 1, 4, 1, 2680, 1, 2, 7, 3, 2, 0]
+            }];
+            var msg = snmp.encode(pkt);
+            assert.equal(msg.toString('hex'), correct);
+        });
+        it('returns a correctly formatted buffer from a NoSuchInstance packet', function () {
+            var correct = '302c 0201 0104 0770 7269 7661 7465 a01e 0201 0502 0106 0201 0730 1330 1106 0d2b 0601 0401 9478 0102 0703 0200 8100'.replace(/ /g, '');
+            var pkt = new snmp.Packet(); // A default getrequest
+            pkt.community = 'private';
+            pkt.pdu.reqid = 5;
+            pkt.pdu.error = 6;
+            pkt.pdu.errorIndex = 7;
+            pkt.pdu.varbinds = [{
+                type: 0x81,
+                oid: [1, 3, 6, 1, 4, 1, 2680, 1, 2, 7, 3, 2, 0]
+            }];
+            var msg = snmp.encode(pkt);
+            assert.equal(msg.toString('hex'), correct);
+        });
+        it('returns a correctly formatted buffer from a NoSuchObject packet', function () {
+            var correct = '302c 0201 0104 0770 7269 7661 7465 a01e 0201 0502 0106 0201 0730 1330 1106 0d2b 0601 0401 9478 0102 0703 0200 8200'.replace(/ /g, '');
+            var pkt = new snmp.Packet(); // A default getrequest
+            pkt.community = 'private';
+            pkt.pdu.reqid = 5;
+            pkt.pdu.error = 6;
+            pkt.pdu.errorIndex = 7;
+            pkt.pdu.varbinds = [{
+                type: 0x82,
+                oid: [1, 3, 6, 1, 4, 1, 2680, 1, 2, 7, 3, 2, 0]
+            }];
+            var msg = snmp.encode(pkt);
+            assert.equal(msg.toString('hex'), correct);
+        });
     });
 
     describe('parse()', function () {
@@ -162,4 +204,3 @@ describe('snmp', function () {
         });
     });
 });
-


### PR DESCRIPTION
I'm using `encoder()` to encode response data and found that there wasn't an encoder for `EndOfMibView`. I've added it here along with encoders for `NoSuchObject` and `NoSuchInstance`.