### PR TITLE
Avoid duplicate request id while create multi sessions at the same time

### DIFF
--- a/lib/snmp.js
+++ b/lib/snmp.js
@@ -502,26 +502,25 @@ exports.Session = Session;
 // ~1000 seconds. This is OK since we only need to keep unique ID:s for in
 // flight packets and they should be safely timed out by then.
 
-Session.prototype.requestId = function () {
-    var self = this, now = Date.now();
+exports.requestId = (function () {
+    var prevTs = Date.now(), counter = 0;
 
-    if (!self.prevTs) {
-        self.prevTs = now;
-        self.counter = 0;
-    }
+    return function () {
+        var now = Date.now();
 
-    if (now === self.prevTs) {
-        self.counter += 1;
-        if (self.counter > 1023) {
-            throw new Error('Request ID counter overflow. Adjust algorithm.');
+        if (now === prevTs) {
+            counter += 1;
+            if (counter > 1023) {
+                throw new Error('Request ID counter overflow. Adjust algorithm.');
+            }
+        } else {
+            prevTs = now;
+            counter = 0;
         }
-    } else {
-        self.prevTs = now;
-        self.counter = 0;
-    }
 
-    return ((now & 0x1fffff) << 10) + self.counter;
-};
+        return ((now & 0x1fffff) << 10) + counter;
+    }
+})();
 
 // Display useful debugging information when a parse error occurs.
 
@@ -559,7 +558,7 @@ Session.prototype.sendMsg = function (pkt, options, callback) {
 
     defaults(options, self.options);
 
-    reqid = self.requestId();
+    reqid = exports.requestId();
     pkt.pdu.reqid = reqid;
 
     buf = encode(pkt);


### PR DESCRIPTION
While create a lot of session at the same time for multi hosts and OIDs, it may cause same request id in different session，and the result will mixed and cause value error。