### PR TITLE
Remove console output (fixes #63)

### DIFF
--- a/lib/snmp.js
+++ b/lib/snmp.js
@@ -410,7 +410,7 @@ function msgReceived(msg, rinfo) {
     try {
         pkt = parse(msg);
     } catch (error) {
-        return self.parseError(error, msg);
+        return self.emit('error', error);
     }
 
     // If this message's request id matches one we've sent,
@@ -521,35 +521,6 @@ Session.prototype.requestId = function () {
     }
 
     return ((now & 0x1fffff) << 10) + self.counter;
-};
-
-// Display useful debugging information when a parse error occurs.
-
-Session.prototype.parseError = function (error, buffer) {
-    var self = this, hex;
-
-    // Display a friendly introductory text.
-    console.error('Woops! An error occurred while parsing an SNMP message. :(');
-    console.error('To have this problem corrected, please report the information below verbatim');
-    console.error('via email to snmp@nym.se or by creating a GitHub issue at');
-    console.error('https://github.com/calmh/node-snmp-native/issues');
-    console.error('');
-    console.error('Thanks!');
-
-    // Display the stack backtrace so we know where the exception happened.
-    console.error('');
-    console.error(error.stack);
-
-    // Display the buffer data, nicely formatted so we can replicate the problem.
-    console.error('\nMessage data:');
-    hex = buffer.toString('hex');
-    while (hex.length > 0) {
-        console.error('    ' + hex.slice(0, 32).replace(/([0-9a-f]{2})/g, '$1 '));
-        hex = hex.slice(32);
-    }
-
-    // Let the exception bubble upwards.
-    self.emit('error', error);
 };
 
 // Send a message. Can be used after manually constructing a correct Packet structure.

--- a/lib/snmp.js
+++ b/lib/snmp.js
@@ -438,16 +438,6 @@ function msgReceived(msg, rinfo) {
 
             entry.callback(null, pkt.pdu.varbinds);
         }
-    } else {
-        // This happens if we receive the response to a message we've already timed out
-        // and removed the request entry for. Maybe we shouldn't even log the warning.
-
-        // Calculate the approximate send time and how old the packet is.
-        var age = (Date.now() & 0x1fffff) - (pkt.pdu.reqid >>> 10);
-        if (age < 0) {
-            age += 0x200000;
-        }
-        console.warn('Response with unknown request ID from ' + rinfo.address + '. Consider increasing timeouts (' + age + ' ms old?).');
     }
 }
 


### PR DESCRIPTION
Emitting an error event on errors is fine. We have no business printing
stuff to the console from a library. The message has also never proven
itself actually useful.