### PR TITLE
Update Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: node_js
 node_js:
-  - 0.10
+  - node
+  - lts/*
+  - '12'
+  - '10'
+  - '8'
+cache: yarn


### PR DESCRIPTION
Currently `node-snmp-native` uses Mocha, in which uses ES6 arrow function syntax. Because of that, Travis CI failed to build on Node.js v0.10.48.
Therefore, it's reasonable to update Travis CI to build on newer versions of Node.js. Here I add support for these versions: the latest stable, latest LTS, 12, 10 and 8.